### PR TITLE
Add accessibility functionality to onscreen slides 

### DIFF
--- a/js/animate.js
+++ b/js/animate.js
@@ -127,6 +127,8 @@ proto.settle = function( previousX ) {
     this.positionSlider();
     this.dispatchEvent( 'settle', null, [ this.selectedIndex ] );
   }
+
+  this.checkVisibility();
 };
 
 proto.shiftWrapCells = function( x ) {

--- a/js/drag.js
+++ b/js/drag.js
@@ -83,6 +83,8 @@ proto.updateDraggable = function() {
   // disable dragging if less than 2 slides. #278
   if ( this.options.draggable == '>1' ) {
     this.isDraggable = this.slides.length > 1;
+  } else if (this.options.draggable === 'onOverflow') {
+    this.isDraggable = this.viewport.scrollWidth > this.viewport.offsetWidth;
   } else {
     this.isDraggable = this.options.draggable;
   }

--- a/js/flickity.js
+++ b/js/flickity.js
@@ -757,6 +757,27 @@ proto.queryCell = function( selector ) {
   return this.getCell( selector );
 };
 
+proto.checkVisibility = function() {
+  var viewportX = this.viewport.getBoundingClientRect().x;
+  var viewportWidth = this.viewport.offsetWidth;
+
+  this.cells.forEach(function (cell) {
+    var cellX = cell.element.getBoundingClientRect().x - viewportX;
+    var isVisible = (
+        (cellX + cell.size.innerWidth > viewportX) && (cellX + cell.size.innerWidth < viewportWidth) ||
+        (cellX > viewportX) && (cellX < viewportWidth)
+    );
+
+    if (isVisible) {
+      cell.element.classList.add('is-visible');
+      cell.element.removeAttribute('aria-hidden');
+    } else {
+      cell.element.classList.remove('is-visible');
+      cell.element.setAttribute('aria-hidden', true);
+    }
+  });
+};
+
 // -------------------------- events -------------------------- //
 
 proto.uiChange = function() {

--- a/js/flickity.js
+++ b/js/flickity.js
@@ -771,9 +771,16 @@ proto.checkVisibility = function() {
     if (isVisible) {
       cell.element.classList.add('is-visible');
       cell.element.removeAttribute('aria-hidden');
+      const targetable =  cell.element.querySelectorAll('button, a');
+
+      targetable.forEach(target => target.tabIndex = 0);
+
     } else {
       cell.element.classList.remove('is-visible');
       cell.element.setAttribute('aria-hidden', true);
+      const targetable =  cell.element.querySelectorAll('button, a');
+
+      targetable.forEach(target => target.tabIndex = -1);
     }
   });
 };

--- a/js/slide.js
+++ b/js/slide.js
@@ -51,6 +51,8 @@ proto.getLastCell = function() {
 };
 
 proto.select = function() {
+  this.parent.checkVisibility();
+  
   this.cells.forEach( function( cell ) {
     cell.select();
   } );

--- a/sandbox/basic.html
+++ b/sandbox/basic.html
@@ -143,6 +143,18 @@
 
   <h2>watch, activate >900px</h2>
 
+  <h2>contain, only draggable if overflow</h2>
+
+  <div class="container variable-width js-flickity"
+       data-flickity-options='{ "contain": true, "cellAlign": "left", "draggable": "onOverflow" }'>
+    <div class="cell n1">1</div>
+    <div class="cell n2">2</div>
+    <div class="cell n3">3</div>
+    <div class="cell n4">4</div>
+    <div class="cell n5">5</div>
+    <div class="cell n6">6</div>
+  </div>
+
   <div id="gallery5" class="container variable-width js-flickity"
     data-flickity-options='{ "wrapAround": true, "watchCSS": true }'>
     <div class="cell n1 w3"></div>


### PR DESCRIPTION
### Overview

This PR copies all functionality given here:
https://github.com/metafizzy/flickity/pull/1032

Flickity automatically sets all slides to `aria-hidden="true"` except the one currently selected. 

This is bad for accessibility. Anything that is `aria-hidden` should not have focusable elements. This creates sliders that can only show one slide at a time to screen readers, or that will not show the furthest most slides at all if `contain: true`.

### Usage
This PR will be kept open. If any changes are released to flickity we pull into our fork then rebase this branch.

To update to use this PR change package.json:
"flickity": "^2.2.2"
**to**
"flickity": "https://github.com/fluorescent/flickity#af2adbb"
