### PR TITLE
Account for Lorenza offset

### DIFF
--- a/js/flickity.js
+++ b/js/flickity.js
@@ -771,6 +771,7 @@ proto.checkVisibility = function() {
   this.cells.forEach(function (cell) {
     var cellX = cell.element.getBoundingClientRect().x - viewportX;
     var isVisible = (
+        (cellX > -1 && cellX < 1) ||
         (cellX + cell.size.innerWidth > viewportX) && (cellX + cell.size.innerWidth < viewportWidth) ||
         (cellX > viewportX) && (cellX < viewportWidth)
     );

--- a/js/flickity.js
+++ b/js/flickity.js
@@ -761,6 +761,13 @@ proto.checkVisibility = function() {
   var viewportX = this.viewport.getBoundingClientRect().x;
   var viewportWidth = this.viewport.offsetWidth;
 
+  // Lorenza pulls content that should be out of the viewport in to
+  // force slides on either side of the viewport. We need to offset
+  // the viewport by the maximum amount it can be pulled in 4px.
+  if (this.options.wrapAround) {
+    viewportWidth = viewportWidth - 4;
+  }
+
   this.cells.forEach(function (cell) {
     var cellX = cell.element.getBoundingClientRect().x - viewportX;
     var isVisible = (


### PR DESCRIPTION
### Overview

Lorenza uses an offset on each slide that is within a wrapAround slider. This offset tricks Flickity into keeping slides overhanging the righthand side of the slider. This allows us to keep these slides from shifting to the start of the queue and moving to the left right after they have left the viewport. 

The offset is by 1px for each slide, with a maximum of 4 slides.

This change allows us to offset the viewport width calculated within https://github.com/fluorescent/flickity/pull/1. We're offsetting by the maximum 4 pixels.


### Edit

A problem with inline carousels has been found. Solution has been added and a note has been made on the original Flickity PR

### Usage
`"flickity": "https://github.com/fluorescent/flickity#e627ff7",`